### PR TITLE
Improve configuration loading and CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ export HMC_USER=myuser
 # omit HMC_PASS to be prompted securely
 ```
 
+Alternatively, configuration values can be provided in a YAML file at
+`~/.hmc_orchestrator.yaml`:
+
+```yaml
+host: hmc.example.com
+username: myuser
+password: secret
+# verify: true
+# ca_bundle: /path/to/ca.pem
+```
+
 Listing LPARs:
 
 ```bash

--- a/src/hmc_power_orchestrator/api.py
+++ b/src/hmc_power_orchestrator/api.py
@@ -1,6 +1,7 @@
 """Minimal HMC REST API client."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Iterable
 
 from .config import Settings
@@ -13,7 +14,9 @@ class HMCClient:
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
         verify: bool | str = (
-            settings.verify if settings.ca_bundle is None else str(settings.ca_bundle)
+            str(settings.verify)
+            if isinstance(settings.verify, Path)
+            else settings.verify
         )
         self._client = HTTPClient(
             base_url=settings.base_url,

--- a/src/hmc_power_orchestrator/cli.py
+++ b/src/hmc_power_orchestrator/cli.py
@@ -37,6 +37,10 @@ def resize(
         f"cpu={cpu}, mem={mem}"
     )
     console.log(msg)
+    if not dry_run and not yes:
+        proceed = typer.confirm("Apply changes?", default=False)
+        if not proceed:
+            raise typer.Exit()
     if not dry_run:
         client.resize_lpar(lpar, cpu, mem)
 
@@ -64,7 +68,7 @@ def policy_dry_run(file: typer.FileText) -> None:
         console.print(msg)
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def main(
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose logging"

--- a/src/hmc_power_orchestrator/config.py
+++ b/src/hmc_power_orchestrator/config.py
@@ -5,7 +5,9 @@ import os
 from dataclasses import dataclass
 from getpass import getpass
 from pathlib import Path
-from typing import Optional
+from typing import Any
+
+import yaml
 
 from .utils import parse_bool
 
@@ -15,8 +17,7 @@ class Settings:
     host: str
     username: str
     password: str
-    verify: bool = True
-    ca_bundle: Optional[Path] = None
+    verify: bool | Path = True
     timeout: int = 30
 
     @property
@@ -28,27 +29,57 @@ class ConfigError(RuntimeError):
     """Raised when mandatory configuration is missing."""
 
 
+def _load_file_config() -> dict[str, Any]:
+    config_path = Path.home() / ".hmc_orchestrator.yaml"
+    if config_path.exists():
+        with config_path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+            if not isinstance(data, dict):
+                return {}
+            return data
+    return {}
+
+
 def load() -> Settings:
-    """Load settings from environment variables, prompting for missing password."""
-    host = os.getenv("HMC_HOST")
+    """Load settings from environment variables or YAML config file."""
+    file_cfg = _load_file_config()
+
+    host = os.getenv("HMC_HOST") or file_cfg.get("host")
+    if not host and (base_url := file_cfg.get("base_url")):
+        host = base_url.replace("https://", "").rstrip("/")
     if not host:
         raise ConfigError("Environment variable HMC_HOST is required")
-    user = os.getenv("HMC_USER")
+
+    user = os.getenv("HMC_USER") or file_cfg.get("username") or file_cfg.get("user")
     if not user:
         raise ConfigError("Environment variable HMC_USER is required")
-    password = os.getenv("HMC_PASS")
+
+    password = os.getenv("HMC_PASS") or file_cfg.get("password")
     if not password:
         password = getpass("HMC password: ")
-    verify_env = os.getenv("HMC_VERIFY")
-    verify = parse_bool(verify_env, default=True)
+
     ca_bundle_env = os.getenv("HMC_CA_BUNDLE")
-    ca_bundle = Path(ca_bundle_env) if ca_bundle_env else None
-    timeout = int(os.getenv("HMC_TIMEOUT", "30"))
+    ca_bundle_file = file_cfg.get("ca_bundle")
+    file_verify = file_cfg.get("verify")
+    default_verify = (
+        parse_bool(str(file_verify), default=True)
+        if file_verify is not None
+        else True
+    )
+    verify: bool | Path
+    if ca_bundle_env:
+        verify = Path(ca_bundle_env)
+    elif ca_bundle_file:
+        verify = Path(str(ca_bundle_file))
+    else:
+        verify = parse_bool(os.getenv("HMC_VERIFY"), default=default_verify)
+
+    timeout = int(os.getenv("HMC_TIMEOUT", str(file_cfg.get("timeout", 30))))
+
     return Settings(
         host=host,
         username=user,
         password=password,
-        verify=verify if ca_bundle is None else True,
-        ca_bundle=ca_bundle,
+        verify=verify,
         timeout=timeout,
     )

--- a/src/hmc_power_orchestrator/exceptions.py
+++ b/src/hmc_power_orchestrator/exceptions.py
@@ -19,3 +19,10 @@ class AuthError(HttpError):
 
 class RateLimitError(HttpError):
     """HMC signalled we exceeded a rate limit."""
+
+
+class NetworkError(RuntimeError):
+    """Network-level error while communicating with the HMC."""
+
+    def __init__(self, exc: requests.RequestException) -> None:
+        super().__init__(str(exc))

--- a/src/hmc_power_orchestrator/http.py
+++ b/src/hmc_power_orchestrator/http.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from urllib.parse import urljoin
 from typing import Any
+from urllib.parse import urljoin
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .exceptions import AuthError, HttpError, RateLimitError
+from .exceptions import AuthError, HttpError, NetworkError, RateLimitError
 
 
 class HTTPClient:
@@ -46,7 +46,12 @@ class HTTPClient:
 
     def _request(self, method: str, path: str, **kwargs: Any) -> requests.Response:
         url = urljoin(self.base_url.rstrip("/") + "/", path.lstrip("/"))
-        response = self._session.request(method, url, timeout=self.timeout, **kwargs)
+        try:
+            response = self._session.request(
+                method, url, timeout=self.timeout, **kwargs
+            )
+        except requests.RequestException as exc:
+            raise NetworkError(exc) from exc
         if response.status_code == 401:
             raise AuthError(response)
         if response.status_code == 429:

--- a/src/hmc_power_orchestrator/utils.py
+++ b/src/hmc_power_orchestrator/utils.py
@@ -44,5 +44,8 @@ def load_policy(text: str) -> dict[str, Any]:
     """Load a policy definition from YAML/JSON text."""
     data = yaml.safe_load(text)
     if not isinstance(data, dict) or "targets" not in data:
-        raise ValueError("policy must contain a 'targets' mapping")
+        present_keys = list(data.keys()) if isinstance(data, dict) else None
+        raise ValueError(
+            f"policy must contain a 'targets' mapping; present keys: {present_keys}"
+        )
     return data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from typer.testing import CliRunner
 
+from hmc_power_orchestrator import __version__, utils
 from hmc_power_orchestrator.cli import app
 
 
@@ -27,3 +28,25 @@ def test_policy_validate_failure(tmp_path):
     runner = CliRunner()
     result = runner.invoke(app, ["policy", "validate", str(file)])
     assert result.exit_code != 0
+
+
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_quiet_option(monkeypatch, tmp_path):
+    file = tmp_path / "p.yaml"
+    file.write_text("targets: []\n")
+    called = {}
+
+    def fake_setup(verbose, quiet=False):
+        called["quiet"] = quiet
+
+    monkeypatch.setattr(utils, "setup_logging", fake_setup)
+    runner = CliRunner()
+    result = runner.invoke(app, ["--quiet", "policy", "validate", str(file)])
+    assert result.exit_code == 0
+    assert called.get("quiet") is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,3 +18,15 @@ def test_missing_host(monkeypatch):
     monkeypatch.setenv("HMC_PASS", "p")
     with pytest.raises(config.ConfigError):
         config.load()
+
+
+def test_file_config_fallback(tmp_path, monkeypatch):
+    cfg_file = tmp_path / ".hmc_orchestrator.yaml"
+    cfg_file.write_text("host: hmc\nusername: user\npassword: secret\n")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("HMC_HOST", raising=False)
+    monkeypatch.delenv("HMC_USER", raising=False)
+    monkeypatch.delenv("HMC_PASS", raising=False)
+    cfg = config.load()
+    assert cfg.username == "user"
+    assert cfg.base_url == "https://hmc"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,6 +1,12 @@
 import pytest
+import requests
 
-from hmc_power_orchestrator.exceptions import AuthError, HttpError, RateLimitError
+from hmc_power_orchestrator.exceptions import (
+    AuthError,
+    HttpError,
+    NetworkError,
+    RateLimitError,
+)
 from hmc_power_orchestrator.http import HTTPClient
 
 
@@ -50,4 +56,15 @@ def test_error_mapping(monkeypatch):
 
     monkeypatch.setattr(client._session, "request", lambda *a, **k: _fake_response(500))
     with pytest.raises(HttpError):
+        client.get("/")
+
+
+def test_network_error(monkeypatch):
+    client = HTTPClient("https://example.com")
+
+    def boom(*a, **k):
+        raise requests.ConnectionError("fail")
+
+    monkeypatch.setattr(client._session, "request", boom)
+    with pytest.raises(NetworkError):
         client.get("/")


### PR DESCRIPTION
## Summary
- restore YAML config file fallback and respect custom CA bundle
- handle network errors and confirmation prompts
- add tests for global flags and configuration file fallback

## Testing
- `PYTHONPATH=src pytest -q -o addopts=`
- `ruff check src tests`

------
https://chatgpt.com/codex/tasks/task_e_68a0c01eafb48323b5c20e9cb280f1c5

## Summary by Sourcery

Improve configuration loading from both environment variables and a YAML file, enhance SSL verification options, handle network errors in HTTP requests, and expand CLI options, tests, and documentation accordingly

New Features:
- Load settings from ~/.hmc_orchestrator.yaml as a fallback to environment variables
- Allow verify field to accept a Path for custom CA bundle or disable SSL verification
- Wrap network-level HTTP errors as NetworkError
- Prompt for confirmation before applying non-dry-run changes without --yes
- Add global --version and --quiet CLI options

Enhancements:
- Improve error message when policy definitions lack the 'targets' mapping

Documentation:
- Document YAML configuration file usage and options in README

Tests:
- Add tests for --version and --quiet CLI options
- Add tests for configuration file fallback and network error handling