### PR TITLE
Improve config handling and expand CLI tests

### DIFF
--- a/src/hmc_power_orchestrator/api.py
+++ b/src/hmc_power_orchestrator/api.py
@@ -12,9 +12,10 @@ class HMCClient:
 
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
-        verify: bool | str = (
-            settings.verify if settings.ca_bundle is None else str(settings.ca_bundle)
-        )
+        if settings.ca_bundle is not None:
+            verify: bool | str = str(settings.ca_bundle) if settings.verify else False
+        else:
+            verify = settings.verify
         self._client = HTTPClient(
             base_url=settings.base_url,
             auth=(settings.username, settings.password),

--- a/src/hmc_power_orchestrator/cli.py
+++ b/src/hmc_power_orchestrator/cli.py
@@ -27,7 +27,6 @@ def resize(
     cpu: int = typer.Option(...),
     mem: int = typer.Option(...),
     dry_run: bool = typer.Option(False, help="Show changes without applying"),
-    yes: bool = typer.Option(False, "--yes", help="Assume yes for any confirmations"),
 ) -> None:
     """Resize CPU or memory for an LPAR."""
     cfg = config.load()
@@ -64,7 +63,7 @@ def policy_dry_run(file: typer.FileText) -> None:
         console.print(msg)
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def main(
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose logging"

--- a/src/hmc_power_orchestrator/exceptions.py
+++ b/src/hmc_power_orchestrator/exceptions.py
@@ -19,3 +19,7 @@ class AuthError(HttpError):
 
 class RateLimitError(HttpError):
     """HMC signalled we exceeded a rate limit."""
+
+
+class NetworkError(RuntimeError):
+    """A network issue occurred while making a request."""

--- a/src/hmc_power_orchestrator/utils.py
+++ b/src/hmc_power_orchestrator/utils.py
@@ -17,6 +17,7 @@ def setup_logging(verbose: bool, quiet: bool = False) -> None:
     else:
         level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    logging.getLogger().setLevel(level)
 
 
 def parse_bool(value: Optional[str], *, default: bool = False) -> bool:
@@ -44,5 +45,8 @@ def load_policy(text: str) -> dict[str, Any]:
     """Load a policy definition from YAML/JSON text."""
     data = yaml.safe_load(text)
     if not isinstance(data, dict) or "targets" not in data:
-        raise ValueError("policy must contain a 'targets' mapping")
+        present_keys = list(data.keys()) if isinstance(data, dict) else None
+        raise ValueError(
+            f"policy must contain a 'targets' mapping; present keys: {present_keys}"
+        )
     return data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
+import logging
+
 from typer.testing import CliRunner
 
+from hmc_power_orchestrator import __version__
 from hmc_power_orchestrator.cli import app
 
 
@@ -27,3 +30,19 @@ def test_policy_validate_failure(tmp_path):
     runner = CliRunner()
     result = runner.invoke(app, ["policy", "validate", str(file)])
     assert result.exit_code != 0
+
+
+def test_global_version():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == __version__
+
+
+def test_global_quiet_sets_error_level(tmp_path):
+    file = tmp_path / "policy.yaml"
+    file.write_text("targets: []\n")
+    runner = CliRunner()
+    result = runner.invoke(app, ["--quiet", "policy", "validate", str(file)])
+    assert result.exit_code == 0
+    assert logging.getLogger().getEffectiveLevel() == logging.ERROR

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,3 +18,17 @@ def test_missing_host(monkeypatch):
     monkeypatch.setenv("HMC_PASS", "p")
     with pytest.raises(config.ConfigError):
         config.load()
+
+
+def test_file_loading(tmp_path, monkeypatch):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("host: h\nusername: u\npassword: p\nverify: false\n")
+    monkeypatch.setenv("HMC_CONFIG", str(cfg))
+    monkeypatch.delenv("HMC_HOST", raising=False)
+    monkeypatch.delenv("HMC_USER", raising=False)
+    monkeypatch.delenv("HMC_PASS", raising=False)
+    loaded = config.load()
+    assert loaded.host == "h"
+    assert loaded.username == "u"
+    assert loaded.password == "p"
+    assert loaded.verify is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,6 +1,12 @@
 import pytest
+import requests
 
-from hmc_power_orchestrator.exceptions import AuthError, HttpError, RateLimitError
+from hmc_power_orchestrator.exceptions import (
+    AuthError,
+    HttpError,
+    NetworkError,
+    RateLimitError,
+)
 from hmc_power_orchestrator.http import HTTPClient
 
 
@@ -50,4 +56,15 @@ def test_error_mapping(monkeypatch):
 
     monkeypatch.setattr(client._session, "request", lambda *a, **k: _fake_response(500))
     with pytest.raises(HttpError):
+        client.get("/")
+
+
+def test_network_error(monkeypatch):
+    client = HTTPClient("https://example.com")
+
+    def boom(*a, **k):
+        raise requests.ConnectionError("boom")
+
+    monkeypatch.setattr(client._session, "request", boom)
+    with pytest.raises(NetworkError):
         client.get("/")


### PR DESCRIPTION
## Summary
- restore YAML-based configuration loading and respect custom CA bundle verification
- remove unused `--yes` flag and allow global flags like `--version` without a subcommand
- handle network errors explicitly and improve policy load error messages
- add tests for config file loading, global flags, and network failures

## Testing
- `ruff check src tests`
- `PYTHONPATH=src pytest -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a0c0834ef08323bf75ff27e03f7253

## Summary by Sourcery

Add YAML-based config file support, refine config verification and API client behavior, introduce explicit network error handling, and expand CLI tests for global flags and failure scenarios.

New Features:
- Load configuration from a YAML file in addition to environment variables
- Introduce a NetworkError exception to wrap network-level request failures
- Allow global CLI flags (--version, --quiet, --verbose) to be invoked without a subcommand

Bug Fixes:
- Explicitly catch and wrap requests.RequestException in HTTP client as NetworkError

Enhancements:
- Respect custom CA bundle settings when verifying HTTP requests
- Improve policy validation error messages by listing present keys
- Ensure the root logger level is set consistently in setup_logging

Tests:
- Add tests for config file loading and fallback behavior
- Add tests for global flags (--version, --quiet) handling
- Add tests for network error scenarios in HTTP client

Chores:
- Remove the unused `--yes` confirmation flag from the resize command