### PR TITLE
feat: add circuit breaker and typed HTTP errors

### DIFF
--- a/src/hmc_power_orchestrator/exceptions.py
+++ b/src/hmc_power_orchestrator/exceptions.py
@@ -1,16 +1,32 @@
 """Application specific exception hierarchy."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import requests
 
 
+@dataclass(eq=False)
 class HttpError(RuntimeError):
-    """Base error for unexpected HTTP responses."""
+    """Base error for unexpected HTTP responses.
 
-    def __init__(self, response: requests.Response) -> None:
-        self.status_code = response.status_code
-        snippet = response.text[:200].strip().replace("\n", " ")
-        super().__init__(f"HTTP {self.status_code}: {snippet}")
+    Parameters are stored for richer error reporting and debugging.  The error
+    message is kept concise but includes the HTTP method, URL and status code as
+    well as a short snippet of the response body for quick inspection.
+    """
+
+    method: str
+    url: str
+    status_code: int | None = None
+    snippet: str | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple formatting
+        parts = [self.method.upper(), self.url]
+        if self.status_code is not None:
+            parts.append(f"HTTP {self.status_code}")
+        if self.snippet:
+            parts.append(self.snippet)
+        super().__init__(": ".join(parts))
 
 
 class AuthError(HttpError):
@@ -19,6 +35,14 @@ class AuthError(HttpError):
 
 class RateLimitError(HttpError):
     """HMC signalled we exceeded a rate limit."""
+
+
+class TransientError(HttpError):
+    """Temporary server or network condition – retry might succeed."""
+
+
+class PermanentError(HttpError):
+    """Permanent failure; retrying is unlikely to help."""
 
 
 class NetworkError(RuntimeError):


### PR DESCRIPTION
## Summary
- add TransientError/PermanentError and expand HttpError with request context
- implement simple circuit breaker and error mapping in HTTPClient
- test retry configuration, error mapping, and circuit breaker behaviour

## Testing
- `ruff check .`
- `mypy --strict src` *(fails: Cannot find implementation or library stub for module named "pydantic")*
- `PYTHONPATH=src pytest -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a0c72cfc708323b58e636b1c58a52d

## Summary by Sourcery

Introduce typed HTTP errors and enrich error context, implement a circuit breaker in HTTPClient, and add tests for error mapping and circuit breaker behaviour

New Features:
- Introduce TransientError and PermanentError exceptions and enrich HttpError with HTTP method, URL, status code, and response snippet
- Implement a simple circuit breaker in HTTPClient with configurable failure threshold and cooldown period

Enhancements:
- Update HTTPClient to map status codes to specific error types and record circuit breaker state transitions

Tests:
- Add tests for retry configuration, HTTP error mapping, and circuit breaker opening behaviour