### PR TITLE
Refactor circuit breaker and improve recovery test

### DIFF
--- a/src/hmc_power_orchestrator/http.py
+++ b/src/hmc_power_orchestrator/http.py
@@ -20,6 +20,61 @@ from .exceptions import (
 )
 
 
+class _CircuitBreaker:
+    """Thread-safe state tracker implementing a basic circuit breaker."""
+
+    def __init__(self, threshold: int, cooldown: float) -> None:
+        self._threshold = threshold
+        self._cooldown = cooldown
+        self._failures = 0
+        self._state = "closed"  # closed | open | half-open
+        self._opened_at = 0.0
+        self._lock = Lock()
+
+    # ------------------------------------------------------------------
+    def before_request(self, method: str, url: str) -> None:
+        """Check breaker state and potentially raise ``TransientError``.
+
+        The lock covers the entire method to avoid races between reading and
+        modifying internal state.
+        """
+
+        with self._lock:
+            if self._state == "open":
+                if monotonic() - self._opened_at < self._cooldown:
+                    raise TransientError(method, url, snippet="circuit open")
+                # cooldown passed – allow a single probe request
+                self._state = "half-open"
+            elif self._state == "half-open":
+                # another probe already in progress
+                raise TransientError(method, url, snippet="circuit open")
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._failures = 0
+            self._state = "closed"
+
+    def record_failure(self) -> None:
+        with self._lock:
+            if self._state == "half-open":
+                self._state = "open"
+                self._opened_at = monotonic()
+                self._failures = self._threshold
+                return
+            self._failures += 1
+            if self._failures >= self._threshold:
+                self._state = "open"
+                self._opened_at = monotonic()
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def failures(self) -> int:
+        return self._failures
+
+
 class HTTPClient:
     """Thin wrapper around :class:`requests.Session` with sane retries."""
 
@@ -54,67 +109,42 @@ class HTTPClient:
         if auth is not None:
             self._session.auth = auth
 
-        # circuit breaker state
-        self._cb_threshold = cb_threshold
-        self._cb_cooldown = cb_cooldown
-        self._cb_failures = 0
-        self._cb_state = "closed"  # closed | open | half-open
-        self._cb_opened_at = 0.0
-        self._cb_lock = Lock()
+        self._cb = _CircuitBreaker(cb_threshold, cb_cooldown)
 
-    # ------------------------------------------------------------------
-    # circuit breaker helpers
-    def _cb_before_request(self, method: str, url: str) -> None:
-        with self._cb_lock:
-            if self._cb_state == "open":
-                if monotonic() - self._cb_opened_at < self._cb_cooldown:
-                    raise TransientError(method, url, snippet="circuit open")
-                # cooldown passed – probe request
-                self._cb_state = "half-open"
+    @property
+    def _cb_state(self) -> str:  # pragma: no cover - for tests/introspection
+        return self._cb.state
 
-    def _cb_record_success(self) -> None:
-        with self._cb_lock:
-            self._cb_failures = 0
-            self._cb_state = "closed"
-
-    def _cb_record_failure(self) -> None:
-        with self._cb_lock:
-            if self._cb_state == "half-open":
-                self._cb_state = "open"
-                self._cb_opened_at = monotonic()
-                self._cb_failures = self._cb_threshold
-                return
-            self._cb_failures += 1
-            if self._cb_failures >= self._cb_threshold:
-                self._cb_state = "open"
-                self._cb_opened_at = monotonic()
+    @property
+    def _cb_failures(self) -> int:  # pragma: no cover - for tests/introspection
+        return self._cb.failures
 
     def _request(self, method: str, path: str, **kwargs: Any) -> requests.Response:
         url = urljoin(self.base_url.rstrip("/") + "/", path.lstrip("/"))
-        self._cb_before_request(method, url)
+        self._cb.before_request(method, url)
         try:
             response = self._session.request(
                 method, url, timeout=self.timeout, **kwargs
             )
         except requests.RequestException as exc:
-            self._cb_record_failure()
+            self._cb.record_failure()
             raise NetworkError(exc) from exc
 
         snippet = response.text[:200].strip().replace("\n", " ")
         if response.status_code == 401:
-            self._cb_record_success()
+            self._cb.record_success()
             raise AuthError(method, url, response.status_code, snippet)
         if response.status_code == 429:
-            self._cb_record_failure()
+            self._cb.record_failure()
             raise RateLimitError(method, url, response.status_code, snippet)
         if 500 <= response.status_code:
-            self._cb_record_failure()
+            self._cb.record_failure()
             raise TransientError(method, url, response.status_code, snippet)
         if response.status_code >= 400:
-            self._cb_record_success()
+            self._cb.record_success()
             raise PermanentError(method, url, response.status_code, snippet)
 
-        self._cb_record_success()
+        self._cb.record_success()
         return response
 
     def get(self, path: str, **kwargs: Any) -> requests.Response:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -112,7 +112,12 @@ def test_circuit_breaker_recovery(monkeypatch):
 
     # move time forward past cooldown and return success
     fake_time[0] = 61.0
-    monkeypatch.setattr(client._session, "request", lambda *a, **k: _fake_response(200))
+
+    def succeed(*a, **k):
+        assert client._cb_state == "half-open"
+        return _fake_response(200)
+
+    monkeypatch.setattr(client._session, "request", succeed)
     client.get("/")
     assert client._cb_state == "closed"
     assert client._cb_failures == 0


### PR DESCRIPTION
## Summary
- centralize circuit breaker logic in a dedicated helper class
- fully guard `before_request` with lock and block concurrent probes
- verify half-open state during circuit breaker recovery test

## Testing
- `pre-commit run --files src/hmc_power_orchestrator/http.py tests/test_http.py` *(fail: command not found)*
- `pip install pre-commit` *(fail: tunnel connection failed: 403 Forbidden)*
- `pip install pytest-cov` *(fail: tunnel connection failed: 403 Forbidden)*
- `PYTHONPATH=src pytest --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68a0cf6719208323a5761ef8e0a91894