### PR TITLE
Expose circuit breaker state publicly and annotate internal state

### DIFF
--- a/src/hmc_power_orchestrator/http.py
+++ b/src/hmc_power_orchestrator/http.py
@@ -34,7 +34,7 @@ class _CircuitBreaker:
         self._threshold = threshold
         self._cooldown = cooldown
         self._failures = 0
-        self._state = CircuitBreakerState.CLOSED
+        self._state: CircuitBreakerState = CircuitBreakerState.CLOSED
         self._opened_at = 0.0
         self._lock = Lock()
 
@@ -119,13 +119,11 @@ class HTTPClient:
         self._cb = _CircuitBreaker(cb_threshold, cb_cooldown)
 
     @property
-    def _cb_state(
-        self,
-    ) -> CircuitBreakerState:  # pragma: no cover - for tests/introspection
+    def cb_state(self) -> CircuitBreakerState:  # pragma: no cover - for tests/introspection
         return self._cb.state
 
     @property
-    def _cb_failures(self) -> int:  # pragma: no cover - for tests/introspection
+    def cb_failures(self) -> int:  # pragma: no cover - for tests/introspection
         return self._cb.failures
 
     def _request(self, method: str, path: str, **kwargs: Any) -> requests.Response:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -116,10 +116,10 @@ def test_circuit_breaker_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_time[0] = 61.0
 
     def succeed(*a: Any, **k: Any) -> Any:
-        assert client._cb_state == CircuitBreakerState.HALF_OPEN
+        assert client.cb_state == CircuitBreakerState.HALF_OPEN
         return _fake_response(200)
 
     monkeypatch.setattr(client._session, "request", succeed)
     client.get("/")
-    assert client._cb_state == CircuitBreakerState.CLOSED
-    assert client._cb_failures == 0
+    assert client.cb_state == CircuitBreakerState.CLOSED
+    assert client.cb_failures == 0


### PR DESCRIPTION
## Summary
- Annotate `_CircuitBreaker._state` with `CircuitBreakerState`
- Expose circuit breaker state and failure count via public `HTTPClient` properties
- Update tests to use new public properties

## Testing
- `PYTHONPATH=src pytest -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a0d43ecf4883238f474608d8c9bf77