### PR TITLE
Remove unused imports

### DIFF
--- a/src/hmc_orchestrator/config.py
+++ b/src/hmc_orchestrator/config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Configuration loading for HMC orchestrator."""
 
-from dataclasses import dataclass
 from getpass import getpass
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -15,7 +14,7 @@ try:  # pragma: no cover - fallback when python-dotenv missing
 except Exception:  # pragma: no cover
     def load_dotenv() -> None:
         return None
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 
 
 class Timeout(BaseModel):

--- a/src/hmc_orchestrator/logging.py
+++ b/src/hmc_orchestrator/logging.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 import structlog
 

--- a/src/hmc_orchestrator/session.py
+++ b/src/hmc_orchestrator/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import random
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 from .config import Config

--- a/src/hmc_power_orchestrator/hmc_client.py
+++ b/src/hmc_power_orchestrator/hmc_client.py
@@ -1,7 +1,6 @@
 """Resilient HTTP client for HMC interactions using httpx."""
 from __future__ import annotations
 
-import json
 import random
 import time
 from dataclasses import dataclass
@@ -14,7 +13,6 @@ from .exceptions import (
     AuthError,
     NetworkError,
     PermanentError,
-    RateLimitError,
     TransientError,
 )
 from .observability import METRIC_LATENCY, METRIC_REQUESTS, get_logger

--- a/src/hmc_power_orchestrator/policy.py
+++ b/src/hmc_power_orchestrator/policy.py
@@ -1,10 +1,9 @@
 """Policy schema and validation models."""
 from __future__ import annotations
 
-from datetime import time
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
 
 class Target(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,3 @@
-import os
-from pathlib import Path
-
 from hmc_orchestrator.config import load_config
 
 


### PR DESCRIPTION
## Summary
- tidy unused imports across client, policy, config, logging, session, and tests

## Testing
- `ruff check src tests` *(fails: module level imports not at top of file, line too long, unsorted imports, etc.)*
- `ruff check --select F401 src/hmc_power_orchestrator/hmc_client.py src/hmc_power_orchestrator/policy.py src/hmc_orchestrator/config.py src/hmc_orchestrator/logging.py src/hmc_orchestrator/session.py tests/test_config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66431cf888323beb1d81b2da2d004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Cleaned up unused imports across multiple modules to streamline the codebase and improve maintainability. No changes to behavior or public APIs.
  * Minor footprint and linting improvements from reduced dependencies.
* Tests
  * Removed unused imports in test files to keep tests lean. No impact on test coverage or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->