### PR TITLE
refactor: avoid name shadowing and tidy imports

### DIFF
--- a/src/hmc_orchestrator/cli.py
+++ b/src/hmc_orchestrator/cli.py
@@ -61,14 +61,14 @@ async def _list(cfg: Config, json_out: bool) -> None:
                 )
 
 
-@app.command()
-def list(  # type: ignore[override]
-    json: bool = typer.Option(False, "--json", help="Output JSON"),
+@app.command("list")
+def list_cmd(  # type: ignore[override]
+    json_out: bool = typer.Option(False, "--json", help="Output JSON"),
 ) -> None:
     """List managed systems and LPARs."""
 
     cfg = load_config()
-    asyncio.run(_list(cfg, json))
+    asyncio.run(_list(cfg, json_out))
 
 
 @policy_app.command("validate")

--- a/src/hmc_orchestrator/config.py
+++ b/src/hmc_orchestrator/config.py
@@ -1,20 +1,20 @@
-from __future__ import annotations
-
 """Configuration loading for HMC orchestrator."""
 
+from __future__ import annotations
+
+import os
 from getpass import getpass
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-import os
-
 import yaml
+from pydantic import BaseModel, Field
+
 try:  # pragma: no cover - fallback when python-dotenv missing
     from dotenv import load_dotenv
 except Exception:  # pragma: no cover
     def load_dotenv() -> None:
         return None
-from pydantic import BaseModel, Field
 
 
 class Timeout(BaseModel):

--- a/src/hmc_orchestrator/hmc_api.py
+++ b/src/hmc_orchestrator/hmc_api.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Minimal typed wrappers for HMC UOM and PCM endpoints."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List

--- a/src/hmc_orchestrator/logging.py
+++ b/src/hmc_orchestrator/logging.py
@@ -7,12 +7,12 @@ import logging
 import structlog
 
 
-def setup_logging(json: bool = False) -> None:
+def setup_logging(as_json: bool = False) -> None:
     """Configure structlog for console or JSON output."""
 
     timestamper = structlog.processors.TimeStamper(fmt="iso")
     processors = [timestamper]
-    if json:
+    if as_json:
         processors.append(structlog.processors.JSONRenderer())
     else:
         processors.append(structlog.dev.ConsoleRenderer())

--- a/src/hmc_power_orchestrator/cli.py
+++ b/src/hmc_power_orchestrator/cli.py
@@ -152,7 +152,7 @@ def apply(
 
 
 @app.callback()
-def main(run_id: str = run_id_option) -> None:
+def main(_run_id: str = run_id_option) -> None:
     pass
 
 

--- a/src/hmc_power_orchestrator/http.py
+++ b/src/hmc_power_orchestrator/http.py
@@ -119,7 +119,7 @@ class HTTPClient:
         self._cb = _CircuitBreaker(cb_threshold, cb_cooldown)
 
     @property
-    def cb_state(self) -> CircuitBreakerState:  # pragma: no cover - for tests/introspection
+    def cb_state(self) -> CircuitBreakerState:  # pragma: no cover - for tests
         return self._cb.state
 
     @property

--- a/src/hmc_power_orchestrator/models.py
+++ b/src/hmc_power_orchestrator/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 
 class LPAR(BaseModel):
-    id: str
+    uuid: str
     name: str
     processors: int
     memory_mb: int


### PR DESCRIPTION
## Summary
- refactor CLI list command to avoid shadowing built-ins
- rename LPAR id field to uuid and clean up logging helper
- fix style issues flagged by ruff

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a72d19c5c883239b6678fd196daf36