### PR TITLE
refactor: remove unused schema_path

### DIFF
--- a/src/hmc_orchestrator/cli.py
+++ b/src/hmc_orchestrator/cli.py
@@ -75,7 +75,7 @@ def list_cmd(  # type: ignore[override]
 def policy_validate(path: Path) -> None:
     """Validate a policy YAML file."""
 
-    load_policy(str(path), str(Path(__file__).with_name("policy_schema.json")))
+    load_policy(str(path))
     typer.echo("Policy is valid")
 
 
@@ -120,9 +120,7 @@ async def _policy_dry_run(policy_file: Path, report: Optional[Path]) -> None:
     for ms in systems:
         lpars.extend(await api.list_lpars(ms.uuid))
     metrics = {lp.uuid: {"cpu_util_pct": 10.0} for lp in lpars}
-    policy = load_policy(
-        str(policy_file), str(Path(__file__).with_name("policy_schema.json"))
-    )
+    policy = load_policy(str(policy_file))
     decisions = evaluate(policy, lpars, metrics)
     await sess.logout()
     await sess.close()

--- a/src/hmc_orchestrator/policy_engine.py
+++ b/src/hmc_orchestrator/policy_engine.py
@@ -34,7 +34,7 @@ class Decision:
     cooldown_remaining: int
 
 
-def load_policy(path: str, schema_path: str) -> Dict[str, Any]:
+def load_policy(path: str) -> Dict[str, Any]:
     """Load policy and perform minimal structural validation."""
 
     with open(path, "r", encoding="utf8") as fh:


### PR DESCRIPTION
## Summary
- drop unused `schema_path` parameter from policy loading
- simplify CLI calls to match new signature

## Testing
- `ruff check src/hmc_orchestrator tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a732772e048323bb839911ee584de6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified policy loading: no separate schema file is required; policies are validated automatically on load.
  * Updated CLI commands (including validation and dry-run) to use the streamlined policy loading, reducing required inputs.
  * No change to validation behavior; existing policies will pass/fail as before.
  * Note: Scripts or automations that previously supplied a schema argument should be updated to remove it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->