### PR TITLE
Validate policy file paths to block traversal

### DIFF
--- a/tests/test_policy_path_traversal.py
+++ b/tests/test_policy_path_traversal.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hmc_orchestrator.policy_engine import load_policy
+
+
+def test_load_policy_blocks_path_traversal(tmp_path: Path) -> None:
+    outside = tmp_path / "policy.yaml"
+    outside.write_text("rules: []")
+    rel = os.path.relpath(outside, Path.cwd())
+    assert rel.startswith("..")
+    with pytest.raises(ValueError):
+        load_policy(rel)


### PR DESCRIPTION
## Summary
- guard policy loading against directory traversal outside the working tree
- add regression test for path traversal attempts

## Testing
- `ruff check src tests`
- `pytest -q`
- `mypy src/hmc_orchestrator/policy_engine.py tests/test_policy_path_traversal.py` *(fails: missing stubs and type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a7356f2c1083238ce1b40c3e0358e3