### PR TITLE
chore: report test coverage to DeepSource

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,3 +5,7 @@ name = "python"
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+
+[[analyzers]]
+name = "test-coverage"
+enabled = true

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,35 @@
+name: Test coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          pip install -r requirements.txt || true
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src --cov-report=xml
+
+      - name: Install DeepSource CLI
+        run: curl https://deepsource.io/cli | sh
+
+      - name: Report coverage to DeepSource
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+        run: ./bin/deepsource report --analyzer test-coverage --key python --value-file coverage.xml


### PR DESCRIPTION
## Summary
- enable DeepSource test-coverage analyzer
- report coverage from GitHub Actions via DeepSource CLI

## Testing
- `python -m pip install -r requirements.txt pytest pytest-cov` *(fails: Could not find a version that satisfies the requirement pytest-cov)*
- `pytest --cov=src --cov-report=xml` *(fails: pytest: error: unrecognized arguments: --cov=src --cov-report=xml)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a1316948323bf19deeef332742e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced automated test coverage reporting in continuous integration, running on pushes and pull requests.
  - Integrated coverage upload to DeepSource for centralized visibility into coverage trends.
  - Standardized Python environment setup and dependency installation in the workflow.
  - Added configuration to enable the test coverage analyzer.
  - Minor configuration cleanups (e.g., ensuring proper file termination).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->